### PR TITLE
Updating illuminate/validation version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "illuminate/validation": "5.0.*|5.1.*"
+        "illuminate/validation": "^5.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The dependency is out of date and causes issues with other dependencies that require newer versions of dependencies for illuminate/validation (i.e. symfony/http-foundation)